### PR TITLE
Add basic HTML/CSS frontend

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,118 @@
+const API_BASE = '/api/';
+
+function showMessage(text, type = 'success') {
+  const box = document.getElementById('message');
+  box.textContent = text;
+  box.className = `message ${type}`;
+  box.classList.remove('hidden');
+  setTimeout(() => box.classList.add('hidden'), 3000);
+}
+
+async function login(e) {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+
+  const response = await fetch(API_BASE + 'auth/token/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+
+  if (response.ok) {
+    const data = await response.json();
+    localStorage.setItem('access', data.access);
+    document.getElementById('login-section').classList.add('hidden');
+    document.getElementById('app').classList.remove('hidden');
+    document.getElementById('logout').classList.remove('hidden');
+    await loadCategories();
+    await loadExpenses();
+    showMessage('Logged in', 'success');
+  } else {
+    showMessage('Login failed', 'error');
+  }
+}
+
+function logout() {
+  localStorage.removeItem('access');
+  document.getElementById('app').classList.add('hidden');
+  document.getElementById('login-section').classList.remove('hidden');
+  document.getElementById('logout').classList.add('hidden');
+  showMessage('Logged out', 'success');
+}
+
+async function loadCategories() {
+  const response = await fetch(API_BASE + 'categories/', {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (response.ok) {
+    const data = await response.json();
+    const select = document.getElementById('category');
+    select.innerHTML = '';
+    data.forEach((cat) => {
+      const option = document.createElement('option');
+      option.value = cat.id;
+      option.textContent = cat.name;
+      select.appendChild(option);
+    });
+  }
+}
+
+async function loadExpenses() {
+  const response = await fetch(API_BASE + 'expenses/', {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (response.ok) {
+    const data = await response.json();
+    const tbody = document.querySelector('#expenses-table tbody');
+    tbody.innerHTML = '';
+    data.forEach((exp) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${exp.description || ''}</td>
+        <td>${exp.amount}</td>
+        <td>${exp.category ? exp.category.name : ''}</td>
+        <td>${exp.date}</td>
+      `;
+      tbody.appendChild(tr);
+    });
+  }
+}
+
+async function addExpense(e) {
+  e.preventDefault();
+  const payload = {
+    description: document.getElementById('description').value,
+    amount: document.getElementById('amount').value,
+    category_id: document.getElementById('category').value,
+    date: document.getElementById('date').value,
+  };
+
+  const response = await fetch(API_BASE + 'expenses/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('access')}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (response.ok) {
+    document.getElementById('expense-form').reset();
+    await loadExpenses();
+    showMessage('Expense added', 'success');
+  } else {
+    showMessage('Failed to add expense', 'error');
+  }
+}
+
+document.getElementById('login-form').addEventListener('submit', login);
+document.getElementById('expense-form').addEventListener('submit', addExpense);
+document.getElementById('logout').addEventListener('click', logout);
+
+if (localStorage.getItem('access')) {
+  document.getElementById('login-section').classList.add('hidden');
+  document.getElementById('app').classList.remove('hidden');
+  document.getElementById('logout').classList.remove('hidden');
+  loadCategories();
+  loadExpenses();
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Expense Tracker</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="header">
+    <h1>Expense Tracker</h1>
+    <button id="logout" class="hidden">Logout</button>
+  </header>
+
+  <main class="container">
+    <div id="message" class="message hidden"></div>
+
+    <section id="login-section" class="card">
+      <h2>Login</h2>
+      <form id="login-form">
+        <div class="form-group">
+          <label for="username">Username</label>
+          <input type="text" id="username" required />
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" required />
+        </div>
+        <button type="submit" class="btn-primary">Login</button>
+      </form>
+    </section>
+
+    <section id="app" class="hidden">
+      <section class="card">
+        <h2>Add Expense</h2>
+        <form id="expense-form">
+          <div class="form-group">
+            <label for="description">Description</label>
+            <input type="text" id="description" required />
+          </div>
+          <div class="form-group">
+            <label for="amount">Amount</label>
+            <input type="number" step="0.01" id="amount" required />
+          </div>
+          <div class="form-group">
+            <label for="category">Category</label>
+            <select id="category"></select>
+          </div>
+          <div class="form-group">
+            <label for="date">Date</label>
+            <input type="date" id="date" required />
+          </div>
+          <button type="submit" class="btn-primary">Add</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Expenses</h2>
+        <table id="expenses-table">
+          <thead>
+            <tr>
+              <th>Description</th>
+              <th>Amount</th>
+              <th>Category</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,109 @@
+:root {
+  --primary: #4a90e2;
+  --text-color: #333;
+  --bg-color: #f0f2f5;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+  margin: 0;
+}
+
+.header {
+  background: var(--primary);
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.container {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.btn-primary,
+button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-primary:hover,
+button:hover {
+  background: #357abd;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: var(--primary);
+  color: #fff;
+}
+
+th,
+td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #eee;
+}
+
+tbody tr:nth-child(even) {
+  background: #f9f9f9;
+}
+
+.message {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.message.success {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.message.error {
+  background: #ffefef;
+  color: #c0392b;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- add simple HTML/CSS frontend with card-based layout and logout
- polish styling with Inter font, color variables, and message alerts

## Testing
- `python backend/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a0aea986fc83279d1999ffc1b1bb6e