### PR TITLE
Add frontend nginx service with registration UI and email login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,14 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  frontend:
+    image: nginx:alpine
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+    ports:
+      - "3000:80"
+    depends_on:
+      - web
+
 volumes:
   postgres_data:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10,13 +10,13 @@ function showMessage(text, type = 'success') {
 
 async function login(e) {
   e.preventDefault();
-  const username = document.getElementById('username').value;
+  const email = document.getElementById('email').value;
   const password = document.getElementById('password').value;
 
   const response = await fetch(API_BASE + 'auth/token/', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ email, password }),
   });
 
   if (response.ok) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,8 @@
       <h2>Login</h2>
       <form id="login-form">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" required />
+          <label for="email">Email</label>
+          <input type="email" id="email" required />
         </div>
         <div class="form-group">
           <label for="password">Password</label>
@@ -31,6 +31,7 @@
         </div>
         <button type="submit" class="btn-primary">Login</button>
       </form>
+      <p class="mt-sm">Don't have an account? <a href="register.html">Register</a></p>
     </section>
 
     <section id="app" class="hidden">

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Register - Expense Tracker</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="container">
+    <div id="message" class="message hidden"></div>
+    <section class="card">
+      <h2>Register</h2>
+      <form id="register-form">
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" required />
+        </div>
+        <div class="form-group">
+          <label for="username">Username</label>
+          <input type="text" id="username" required />
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" minlength="8" required />
+        </div>
+        <button type="submit" class="btn-primary">Register</button>
+      </form>
+      <p class="mt-sm"><a href="index.html">Back to login</a></p>
+    </section>
+  </main>
+  <script src="register.js"></script>
+</body>
+</html>

--- a/frontend/register.js
+++ b/frontend/register.js
@@ -1,0 +1,36 @@
+const API_BASE = '/api/';
+
+function showMessage(text, type = 'success') {
+  const box = document.getElementById('message');
+  box.textContent = text;
+  box.className = `message ${type}`;
+  box.classList.remove('hidden');
+  setTimeout(() => box.classList.add('hidden'), 3000);
+}
+
+async function register(e) {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+
+  if (password.length < 8) {
+    showMessage('Password must be at least 8 characters', 'error');
+    return;
+  }
+
+  const response = await fetch(API_BASE + 'auth/register/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, username, password }),
+  });
+
+  if (response.ok) {
+    showMessage('Registration successful', 'success');
+    setTimeout(() => { window.location.href = 'index.html'; }, 1000);
+  } else {
+    showMessage('Registration failed', 'error');
+  }
+}
+
+document.getElementById('register-form').addEventListener('submit', register);


### PR DESCRIPTION
## Summary
- serve `frontend` via nginx container
- allow users to register with email, username, and strong passwords
- authenticate using email instead of username

## Testing
- `docker-compose up --build -d` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68a23525cf888327b2dfc40a7339cedd