### PR TITLE
Add frontend nginx service with registration UI and email login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,14 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  frontend:
+    image: nginx:alpine
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+    ports:
+      - "3000:80"
+    depends_on:
+      - web
+
 volumes:
   postgres_data:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10,13 +10,13 @@ function showMessage(text, type = 'success') {
 
 async function login(e) {
   e.preventDefault();
-  const username = document.getElementById('username').value;
+  const email = document.getElementById('email').value;
   const password = document.getElementById('password').value;
 
   const response = await fetch(API_BASE + 'auth/token/', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ email, password }),
   });
 
   if (response.ok) {
@@ -49,12 +49,78 @@ async function loadCategories() {
     const data = await response.json();
     const select = document.getElementById('category');
     select.innerHTML = '';
+    const tbody = document.querySelector('#categories-table tbody');
+    tbody.innerHTML = '';
     data.forEach((cat) => {
       const option = document.createElement('option');
       option.value = cat.id;
       option.textContent = cat.name;
       select.appendChild(option);
+
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${cat.id}</td>
+        <td>${cat.name}</td>
+        <td>
+          <button class="edit-category" data-id="${cat.id}" data-name="${cat.name}">Edit</button>
+          <button class="delete-category" data-id="${cat.id}">Delete</button>
+        </td>
+      `;
+      tbody.appendChild(tr);
     });
+  }
+}
+
+async function addCategory(e) {
+  e.preventDefault();
+  const name = document.getElementById('category-name').value;
+  const response = await fetch(API_BASE + 'categories/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('access')}`,
+    },
+    body: JSON.stringify({ name }),
+  });
+  if (response.ok) {
+    document.getElementById('category-form').reset();
+    await loadCategories();
+    showMessage('Category added');
+  } else {
+    showMessage('Failed to add category', 'error');
+  }
+}
+
+async function editCategory(id, currentName) {
+  const name = prompt('Category name', currentName);
+  if (name === null) return;
+  const response = await fetch(API_BASE + `categories/${id}/`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('access')}`,
+    },
+    body: JSON.stringify({ name }),
+  });
+  if (response.ok) {
+    await loadCategories();
+    showMessage('Category updated');
+  } else {
+    showMessage('Failed to update category', 'error');
+  }
+}
+
+async function deleteCategory(id) {
+  if (!confirm('Delete category?')) return;
+  const response = await fetch(API_BASE + `categories/${id}/`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (response.ok) {
+    await loadCategories();
+    showMessage('Category deleted');
+  } else {
+    showMessage('Failed to delete category', 'error');
   }
 }
 
@@ -73,6 +139,10 @@ async function loadExpenses() {
         <td>${exp.amount}</td>
         <td>${exp.category ? exp.category.name : ''}</td>
         <td>${exp.date}</td>
+        <td>
+          <button class="edit-expense" data-id="${exp.id}">Edit</button>
+          <button class="delete-expense" data-id="${exp.id}">Delete</button>
+        </td>
       `;
       tbody.appendChild(tr);
     });
@@ -105,9 +175,125 @@ async function addExpense(e) {
   }
 }
 
+async function editExpense(id) {
+  const detail = await fetch(API_BASE + `expenses/${id}/`, {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (!detail.ok) {
+    showMessage('Failed to load expense', 'error');
+    return;
+  }
+  const exp = await detail.json();
+  const description = prompt('Description', exp.description || '');
+  if (description === null) return;
+  const amount = prompt('Amount', exp.amount);
+  if (amount === null) return;
+  const category_id = prompt('Category ID', exp.category ? exp.category.id : '');
+  if (category_id === null) return;
+  const date = prompt('Date', exp.date);
+  if (date === null) return;
+
+  const response = await fetch(API_BASE + `expenses/${id}/`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('access')}`,
+    },
+    body: JSON.stringify({ description, amount, category_id, date }),
+  });
+  if (response.ok) {
+    await loadExpenses();
+    showMessage('Expense updated');
+  } else {
+    showMessage('Failed to update expense', 'error');
+  }
+}
+
+async function deleteExpense(id) {
+  if (!confirm('Delete expense?')) return;
+  const response = await fetch(API_BASE + `expenses/${id}/`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (response.ok) {
+    await loadExpenses();
+    showMessage('Expense deleted');
+  } else {
+    showMessage('Failed to delete expense', 'error');
+  }
+}
+
+function getReportParams() {
+  const params = new URLSearchParams();
+  const from = document.getElementById('report-from').value;
+  const to = document.getElementById('report-to').value;
+  if (from) params.append('date_from', from);
+  if (to) params.append('date_to', to);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+async function showSummary() {
+  const res = await fetch(API_BASE + 'reports/summary/' + getReportParams(), {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('summary-output').textContent =
+      `Income: ${data.income_total}, Expense: ${data.expense_total}, Balance: ${data.balance}`;
+  } else {
+    showMessage('Failed to load summary', 'error');
+  }
+}
+
+async function showByCategory() {
+  const res = await fetch(API_BASE + 'reports/by-category/' + getReportParams(), {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    const table = document.getElementById('by-category-table');
+    const tbody = table.querySelector('tbody');
+    tbody.innerHTML = '';
+    data.forEach((row) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${row.category}</td><td>${row.income}</td><td>${row.expense}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.classList.remove('hidden');
+  } else {
+    showMessage('Failed to load report', 'error');
+  }
+}
+
+function exportCSV() {
+  const url = API_BASE + 'exports/expenses.csv' + getReportParams();
+  window.open(url, '_blank');
+}
+
 document.getElementById('login-form').addEventListener('submit', login);
 document.getElementById('expense-form').addEventListener('submit', addExpense);
 document.getElementById('logout').addEventListener('click', logout);
+document.getElementById('category-form').addEventListener('submit', addCategory);
+document.getElementById('categories-table').addEventListener('click', (e) => {
+  if (e.target.classList.contains('edit-category')) {
+    editCategory(e.target.dataset.id, e.target.dataset.name);
+  } else if (e.target.classList.contains('delete-category')) {
+    deleteCategory(e.target.dataset.id);
+  }
+});
+
+document.getElementById('expenses-table').addEventListener('click', (e) => {
+  if (e.target.classList.contains('edit-expense')) {
+    editExpense(e.target.dataset.id);
+  } else if (e.target.classList.contains('delete-expense')) {
+    deleteExpense(e.target.dataset.id);
+  }
+});
+
+document.getElementById('summary-btn').addEventListener('click', showSummary);
+document.getElementById('by-category-btn').addEventListener('click', showByCategory);
+document.getElementById('export-btn').addEventListener('click', exportCSV);
 
 if (localStorage.getItem('access')) {
   document.getElementById('login-section').classList.add('hidden');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,8 @@
       <h2>Login</h2>
       <form id="login-form">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" required />
+          <label for="email">Email</label>
+          <input type="email" id="email" required />
         </div>
         <div class="form-group">
           <label for="password">Password</label>
@@ -31,9 +31,31 @@
         </div>
         <button type="submit" class="btn-primary">Login</button>
       </form>
+      <p class="mt-sm">Don't have an account? <a href="register.html">Register</a></p>
     </section>
 
     <section id="app" class="hidden">
+      <section class="card">
+        <h2>Categories</h2>
+        <form id="category-form">
+          <div class="form-group">
+            <label for="category-name">Name</label>
+            <input type="text" id="category-name" required />
+          </div>
+          <button type="submit" class="btn-primary">Add Category</button>
+        </form>
+        <table id="categories-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+
       <section class="card">
         <h2>Add Expense</h2>
         <form id="expense-form">
@@ -66,6 +88,35 @@
               <th>Amount</th>
               <th>Category</th>
               <th>Date</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+
+      <section class="card">
+        <h2>Reports</h2>
+        <form id="report-form">
+          <div class="form-group">
+            <label for="report-from">From</label>
+            <input type="date" id="report-from" />
+          </div>
+          <div class="form-group">
+            <label for="report-to">To</label>
+            <input type="date" id="report-to" />
+          </div>
+          <button type="button" id="summary-btn" class="btn-primary">Summary</button>
+          <button type="button" id="by-category-btn" class="btn-primary">By Category</button>
+          <button type="button" id="export-btn">Export CSV</button>
+        </form>
+        <div id="summary-output" class="mt-sm"></div>
+        <table id="by-category-table" class="hidden mt-sm">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Income</th>
+              <th>Expense</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Register - Expense Tracker</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="container">
+    <div id="message" class="message hidden"></div>
+    <section class="card">
+      <h2>Register</h2>
+      <form id="register-form">
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" required />
+        </div>
+        <div class="form-group">
+          <label for="username">Username</label>
+          <input type="text" id="username" required />
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" minlength="8" required />
+        </div>
+        <button type="submit" class="btn-primary">Register</button>
+      </form>
+      <p class="mt-sm"><a href="index.html">Back to login</a></p>
+    </section>
+  </main>
+  <script src="register.js"></script>
+</body>
+</html>

--- a/frontend/register.js
+++ b/frontend/register.js
@@ -1,0 +1,36 @@
+const API_BASE = '/api/';
+
+function showMessage(text, type = 'success') {
+  const box = document.getElementById('message');
+  box.textContent = text;
+  box.className = `message ${type}`;
+  box.classList.remove('hidden');
+  setTimeout(() => box.classList.add('hidden'), 3000);
+}
+
+async function register(e) {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+
+  if (password.length < 8) {
+    showMessage('Password must be at least 8 characters', 'error');
+    return;
+  }
+
+  const response = await fetch(API_BASE + 'auth/register/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, username, password }),
+  });
+
+  if (response.ok) {
+    showMessage('Registration successful', 'success');
+    setTimeout(() => { window.location.href = 'index.html'; }, 1000);
+  } else {
+    showMessage('Registration failed', 'error');
+  }
+}
+
+document.getElementById('register-form').addEventListener('submit', register);


### PR DESCRIPTION
## Summary
- serve `frontend` via nginx container
- allow users to register with email, username, and strong passwords
- authenticate using email instead of username
- manage categories and expenses with edit/delete actions
- generate summary and per-category reports with CSV export

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a23525cf888327b2dfc40a7339cedd