### PR TITLE
feat: add dashboard and admin pages

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin - Expense Tracker</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="header">
+    <h1>Administration</h1>
+    <nav>
+      <a href="index.html" class="btn-primary">Home</a>
+      <button id="logout">Logout</button>
+    </nav>
+  </header>
+
+  <main class="container">
+    <div id="message" class="message hidden"></div>
+
+    <section class="card">
+      <h2>Categories</h2>
+      <form id="category-form">
+        <div class="form-group">
+          <label for="category-name">Name</label>
+          <input type="text" id="category-name" required />
+        </div>
+        <button type="submit" class="btn-primary">Add Category</button>
+      </form>
+      <table id="categories-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>Add Expense</h2>
+      <form id="expense-form">
+        <div class="form-group">
+          <label for="description">Description</label>
+          <input type="text" id="description" required />
+        </div>
+        <div class="form-group">
+          <label for="amount">Amount</label>
+          <input type="number" step="0.01" id="amount" required />
+        </div>
+        <div class="form-group">
+          <label for="category">Category</label>
+          <select id="category"></select>
+        </div>
+        <div class="form-group">
+          <label for="date">Date</label>
+          <input type="date" id="date" required />
+        </div>
+        <button type="submit" class="btn-primary">Add</button>
+      </form>
+    </section>
+
+    <section class="card">
+      <h2>Expenses</h2>
+      <table id="expenses-table">
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th>Amount</th>
+            <th>Category</th>
+            <th>Date</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -8,37 +8,9 @@ function showMessage(text, type = 'success') {
   setTimeout(() => box.classList.add('hidden'), 3000);
 }
 
-async function login(e) {
-  e.preventDefault();
-  const email = document.getElementById('email').value;
-  const password = document.getElementById('password').value;
-
-  const response = await fetch(API_BASE + 'auth/token/', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }),
-  });
-
-  if (response.ok) {
-    const data = await response.json();
-    localStorage.setItem('access', data.access);
-    document.getElementById('login-section').classList.add('hidden');
-    document.getElementById('app').classList.remove('hidden');
-    document.getElementById('logout').classList.remove('hidden');
-    await loadCategories();
-    await loadExpenses();
-    showMessage('Logged in', 'success');
-  } else {
-    showMessage('Login failed', 'error');
-  }
-}
-
 function logout() {
   localStorage.removeItem('access');
-  document.getElementById('app').classList.add('hidden');
-  document.getElementById('login-section').classList.remove('hidden');
-  document.getElementById('logout').classList.add('hidden');
-  showMessage('Logged out', 'success');
+  window.location.href = 'index.html';
 }
 
 async function loadCategories() {
@@ -223,57 +195,7 @@ async function deleteExpense(id) {
   }
 }
 
-function getReportParams() {
-  const params = new URLSearchParams();
-  const from = document.getElementById('report-from').value;
-  const to = document.getElementById('report-to').value;
-  if (from) params.append('date_from', from);
-  if (to) params.append('date_to', to);
-  const query = params.toString();
-  return query ? `?${query}` : '';
-}
-
-async function showSummary() {
-  const res = await fetch(API_BASE + 'reports/summary/' + getReportParams(), {
-    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
-  });
-  if (res.ok) {
-    const data = await res.json();
-    document.getElementById('summary-output').textContent =
-      `Income: ${data.income_total}, Expense: ${data.expense_total}, Balance: ${data.balance}`;
-  } else {
-    showMessage('Failed to load summary', 'error');
-  }
-}
-
-async function showByCategory() {
-  const res = await fetch(API_BASE + 'reports/by-category/' + getReportParams(), {
-    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
-  });
-  if (res.ok) {
-    const data = await res.json();
-    const table = document.getElementById('by-category-table');
-    const tbody = table.querySelector('tbody');
-    tbody.innerHTML = '';
-    data.forEach((row) => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${row.category}</td><td>${row.income}</td><td>${row.expense}</td>`;
-      tbody.appendChild(tr);
-    });
-    table.classList.remove('hidden');
-  } else {
-    showMessage('Failed to load report', 'error');
-  }
-}
-
-function exportCSV() {
-  const url = API_BASE + 'exports/expenses.csv' + getReportParams();
-  window.open(url, '_blank');
-}
-
-document.getElementById('login-form').addEventListener('submit', login);
 document.getElementById('expense-form').addEventListener('submit', addExpense);
-document.getElementById('logout').addEventListener('click', logout);
 document.getElementById('category-form').addEventListener('submit', addCategory);
 document.getElementById('categories-table').addEventListener('click', (e) => {
   if (e.target.classList.contains('edit-category')) {
@@ -291,14 +213,11 @@ document.getElementById('expenses-table').addEventListener('click', (e) => {
   }
 });
 
-document.getElementById('summary-btn').addEventListener('click', showSummary);
-document.getElementById('by-category-btn').addEventListener('click', showByCategory);
-document.getElementById('export-btn').addEventListener('click', exportCSV);
+document.getElementById('logout').addEventListener('click', logout);
 
-if (localStorage.getItem('access')) {
-  document.getElementById('login-section').classList.add('hidden');
-  document.getElementById('app').classList.remove('hidden');
-  document.getElementById('logout').classList.remove('hidden');
+if (!localStorage.getItem('access')) {
+  window.location.href = 'index.html';
+} else {
   loadCategories();
   loadExpenses();
 }

--- a/frontend/home.js
+++ b/frontend/home.js
@@ -1,0 +1,155 @@
+const API_BASE = '/api/';
+let categoryChart;
+
+function showMessage(text, type = 'success') {
+  const box = document.getElementById('message');
+  box.textContent = text;
+  box.className = `message ${type}`;
+  box.classList.remove('hidden');
+  setTimeout(() => box.classList.add('hidden'), 3000);
+}
+
+async function login(e) {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+
+  const response = await fetch(API_BASE + 'auth/token/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (response.ok) {
+    const data = await response.json();
+    localStorage.setItem('access', data.access);
+    document.getElementById('login-section').classList.add('hidden');
+    document.getElementById('app').classList.remove('hidden');
+    document.getElementById('logout').classList.remove('hidden');
+    document.getElementById('admin-link').classList.remove('hidden');
+    await loadExpenses();
+    await showSummary();
+    await showByCategory();
+    showMessage('Logged in', 'success');
+  } else {
+    showMessage('Login failed', 'error');
+  }
+}
+
+function logout() {
+  localStorage.removeItem('access');
+  document.getElementById('app').classList.add('hidden');
+  document.getElementById('login-section').classList.remove('hidden');
+  document.getElementById('logout').classList.add('hidden');
+  document.getElementById('admin-link').classList.add('hidden');
+  if (categoryChart) categoryChart.destroy();
+  showMessage('Logged out', 'success');
+}
+
+async function loadExpenses() {
+  const response = await fetch(API_BASE + 'expenses/', {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (response.ok) {
+    const data = await response.json();
+    const tbody = document.querySelector('#expenses-table tbody');
+    tbody.innerHTML = '';
+    data.forEach((exp) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${exp.description || ''}</td>
+        <td>${exp.amount}</td>
+        <td>${exp.category ? exp.category.name : ''}</td>
+        <td>${exp.date}</td>
+      `;
+      tbody.appendChild(tr);
+    });
+  }
+}
+
+function getReportParams() {
+  const params = new URLSearchParams();
+  const from = document.getElementById('report-from').value;
+  const to = document.getElementById('report-to').value;
+  if (from) params.append('date_from', from);
+  if (to) params.append('date_to', to);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+async function showSummary() {
+  const res = await fetch(API_BASE + 'reports/summary/' + getReportParams(), {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('summary-output').textContent =
+      `Income: ${data.income_total}, Expense: ${data.expense_total}, Balance: ${data.balance}`;
+  } else {
+    showMessage('Failed to load summary', 'error');
+  }
+}
+
+async function showByCategory() {
+  const res = await fetch(API_BASE + 'reports/by-category/' + getReportParams(), {
+    headers: { Authorization: `Bearer ${localStorage.getItem('access')}` },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    const table = document.getElementById('by-category-table');
+    const tbody = table.querySelector('tbody');
+    tbody.innerHTML = '';
+    data.forEach((row) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${row.category}</td><td>${row.income}</td><td>${row.expense}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.classList.remove('hidden');
+    renderCategoryChart(data);
+  } else {
+    showMessage('Failed to load report', 'error');
+  }
+}
+
+function renderCategoryChart(data) {
+  const ctx = document.getElementById('category-chart').getContext('2d');
+  const labels = data.map((row) => row.category);
+  const values = data.map((row) => row.expense);
+  const colors = labels.map(
+    (_, i) => `hsl(${(i * 60) % 360},70%,60%)`
+  );
+  if (categoryChart) categoryChart.destroy();
+  categoryChart = new Chart(ctx, {
+    type: 'pie',
+    data: {
+      labels,
+      datasets: [
+        {
+          data: values,
+          backgroundColor: colors,
+        },
+      ],
+    },
+  });
+}
+
+function exportCSV() {
+  const url = API_BASE + 'exports/expenses.csv' + getReportParams();
+  window.open(url, '_blank');
+}
+
+document.getElementById('login-form').addEventListener('submit', login);
+document.getElementById('logout').addEventListener('click', logout);
+document.getElementById('summary-btn').addEventListener('click', showSummary);
+document.getElementById('by-category-btn').addEventListener('click', showByCategory);
+document.getElementById('export-btn').addEventListener('click', exportCSV);
+
+if (localStorage.getItem('access')) {
+  document.getElementById('login-section').classList.add('hidden');
+  document.getElementById('app').classList.remove('hidden');
+  document.getElementById('logout').classList.remove('hidden');
+  document.getElementById('admin-link').classList.remove('hidden');
+  loadExpenses();
+  showSummary();
+  showByCategory();
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,10 @@
 <body>
   <header class="header">
     <h1>Expense Tracker</h1>
-    <button id="logout" class="hidden">Logout</button>
+    <nav>
+      <a id="admin-link" href="admin.html" class="hidden">Admin</a>
+      <button id="logout" class="hidden">Logout</button>
+    </nav>
   </header>
 
   <main class="container">
@@ -36,50 +39,6 @@
 
     <section id="app" class="hidden">
       <section class="card">
-        <h2>Categories</h2>
-        <form id="category-form">
-          <div class="form-group">
-            <label for="category-name">Name</label>
-            <input type="text" id="category-name" required />
-          </div>
-          <button type="submit" class="btn-primary">Add Category</button>
-        </form>
-        <table id="categories-table">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </section>
-
-      <section class="card">
-        <h2>Add Expense</h2>
-        <form id="expense-form">
-          <div class="form-group">
-            <label for="description">Description</label>
-            <input type="text" id="description" required />
-          </div>
-          <div class="form-group">
-            <label for="amount">Amount</label>
-            <input type="number" step="0.01" id="amount" required />
-          </div>
-          <div class="form-group">
-            <label for="category">Category</label>
-            <select id="category"></select>
-          </div>
-          <div class="form-group">
-            <label for="date">Date</label>
-            <input type="date" id="date" required />
-          </div>
-          <button type="submit" class="btn-primary">Add</button>
-        </form>
-      </section>
-
-      <section class="card">
         <h2>Expenses</h2>
         <table id="expenses-table">
           <thead>
@@ -88,7 +47,6 @@
               <th>Amount</th>
               <th>Category</th>
               <th>Date</th>
-              <th>Actions</th>
             </tr>
           </thead>
           <tbody></tbody>
@@ -121,10 +79,12 @@
           </thead>
           <tbody></tbody>
         </table>
+        <canvas id="category-chart" class="mt-sm"></canvas>
       </section>
     </section>
   </main>
 
-  <script src="app.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="home.js"></script>
 </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -32,6 +32,7 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
   margin-bottom: 2rem;
+  animation: fadeIn 0.5s ease-in;
 }
 
 .form-group {
@@ -106,4 +107,24 @@ tbody tr:nth-child(even) {
 
 .hidden {
   display: none;
+}
+.header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.header a {
+  color: #fff;
+  text-decoration: none;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }


### PR DESCRIPTION
## Summary
- split frontend into Home and Administration pages
- visualize expense distribution with Chart.js pie chart
- add simple animations and navigation styling

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bac9e1c483279063de729b454e2c