### PR TITLE
Serve frontend static files through Django

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -76,6 +76,8 @@ TEMPLATES = [
     },
 ]
 
+TEMPLATES[0]["DIRS"] = [BASE_DIR.parent / "frontend"]
+
 # ──────────────────────────────
 # 🗃️ База данных
 # ──────────────────────────────
@@ -147,6 +149,7 @@ USE_TZ = True
 # ──────────────────────────────
 
 STATIC_URL = "static/"
+STATICFILES_DIRS = [BASE_DIR.parent / "frontend"]
 
 # ──────────────────────────────
 # 🔑 PK по умолчанию

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="{% static 'styles.css' %}" />
 </head>
 <body>
   <header class="header">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="{% static 'styles.css' %}" />
 </head>
 <body>
   <header class="header">

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="{% static 'styles.css' %}" />
 </head>
 <body>
   <main class="container">


### PR DESCRIPTION
## Summary
- Configure Django to load templates and static files from the `frontend` directory.
- Use `{% load static %}` with `{% static 'styles.css' %}` in HTML templates.

## Testing
- `python backend/manage.py check`
- `pip install -r backend/requirements.txt`
- `python backend/manage.py runserver --noreload` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68b04423a3d88327988a0b3b878421b8